### PR TITLE
Changing the way client::request() responses on error and success

### DIFF
--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -15,6 +15,7 @@ class AbstractApi
     {
         $this->client = $client;
     }
+
     /**
      * @return Client
      */

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,8 +2,6 @@
 
 namespace Ahsay;
 
-use Ahsay\Api\User\User;
-
 class Client
 {
     /**
@@ -20,8 +18,6 @@ class Client
      * @var string
      */
     private $application = 'obs';
-
-    private $instances = [];
 
     /**
      * @var string
@@ -112,8 +108,8 @@ class Client
             throw new \RuntimeException(json_last_error_msg(), json_last_error());
         }
 
-        if (isset($data['Status']) && $data['Status'] === 'OK' && isset($data['Data'])) {
-            return $data['Data'];
+        if (isset($data['Status']) && $data['Status'] === 'Error' && isset($data['Message'])) {
+            throw new \Exception($data['Message']);
         }
 
         return $data;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -98,13 +98,30 @@ class ClientTest extends AbstractTestCase
         $this->getClient()->request('endpoint');
     }
 
+    public function testRequestThrowingExceptionOnResponseError()
+    {
+        $error = [
+            'Status' => 'Error',
+            'Message' => '[UserCacheManager.NoSuchUserExpt] User \'aaaa\' not found.',
+            'ExptType' => 'com.ahsay.obs.core.dbs.ad'
+        ];
+
+        $fn1 = $this->getFunctionMock('Ahsay', 'curl_exec');
+        $fn1->expects($this->once())->willReturn(json_encode($error));
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('[UserCacheManager.NoSuchUserExpt] User \'aaaa\' not found.');
+
+        $this->getClient()->request('endpoint');
+    }
+
     public function testRequestWithSuccessWillReturnData()
     {
         $fn1 = $this->getFunctionMock('Ahsay', 'curl_exec');
         $fn1->expects($this->once())->willReturn('{"Status":"OK","Data":{"Key":"Value"}}');
 
         $result = $this->getClient()->request('endpoint');
-        $this->assertEquals(['Key' => 'Value'], $result);
+        $this->assertEquals(['Status' => 'OK', 'Data' => ['Key' => 'Value']], $result);
     }
 
     public function testRequestWithSuccessWithNoDataKeyWillReturnItself()


### PR DESCRIPTION
- Request now throws an exception when api responses with an error description
- Success response now returns all array, instead of only the Data key
- Removed unused import
- Removed unused propertie